### PR TITLE
Add a section about how to submit suggestions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,6 @@
-Guidelines for contributing to webteam-practices
-===
+# Guidelines for contributing to webteam-practices
 
-This repository contains best practices specifically for the Canonical Webteam.
+This repository contains best practices specifically for the Canonical Webteam. The documents contained here should remain concise and of a high quality.
 
 Anyone is welcome to suggest improvements in one of two ways:
 
@@ -9,6 +8,18 @@ Anyone is welcome to suggest improvements in one of two ways:
 - Suggest a change by submitting a pull request ([how?](https://help.github.com/articles/about-pull-requests/))
 
 ## Submitting suggestions
+
+Pull requests are a starting point for discussion. The team should collaborate to refine the suggested points before reaching a consensus.
+
+Since the webteam-practices represent the culture of the whole team it will be common for pull requests to generate discussion before being accepted. Quality and team consensus should take precedence over speed.
+
+Individual pull requests should remain small so that they can be agreed upon and approved more easily. Usually a pull request should not add more than a single subsection to a document.
+
+### Starting a new document
+
+To start a new document, the initial pull request should simply create the document with only a single heading.
+
+This can then be merged more quickly so that others can start adding sections to the new document as soon as possible.
 
 ### Collaborating on large documents
 
@@ -18,13 +29,14 @@ To get around this it may make more sense to ask the team to collaborate on long
 
 The parts of the newly created document should then be submitted as pull requests in the normal way, subject to all the normal rules of approval, but if most of the relevant team members were already involved in the collaborative phase then approval should go by much more easily.
 
-Approving a pull request
----
+## Approving a pull request
 
 Before a pull request is approved and merged:
 
 - A reasonable effort should be made to bring it to the attention of the whole team
 - It should also have been :+1:d by at least 2 team members
 - It should have been open for at least 24 hours
+  - For expediency, this rule does not apply to pull requests to create new [empty documents](#starting-a-new-document)
 
 Once it is merged, it should be brought up in the next relevant team meeting to ensure the whole team is aware of the change.
+


### PR DESCRIPTION
For the CONTRIBUTING.md, we should mention more specifically how to submit suggestions.

Here I'm trying to emphasise:

- PRs should remain small
- We should expect that PRs should generate discussion
- That new documents should be created empty apart from a heading, to help future work go faster (as [previously mentioned](https://github.com/ubuntudesign/webteam-practices/pull/13#issuecomment-275695203)).