### PR TITLE
Add introductory section about reviewing pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,13 @@ To get around this it may make more sense to ask the team to collaborate on long
 
 The parts of the newly created document should then be submitted as pull requests in the normal way, subject to all the normal rules of approval, but if most of the relevant team members were already involved in the collaborative phase then approval should go by much more easily.
 
-## Approving a pull request
+## Reviewing pull requests
+
+As this repository represents the whole team, team members should try to collaborate on any pull request they are aware of.
+
+To encourage participation and activity on the project, comments should remain as polite and accommodating as possible. The [GitHub reviews](https://help.github.com/articles/about-pull-request-reviews/) features ("approve" and "request changes") should *not* be used, as all discussion is merely a discussion of opinions.
+
+### Approval criteria
 
 Before a pull request is approved and merged:
 


### PR DESCRIPTION
I'm making the "approval criteria" a sub-heading under "reviewing pull requests" as I think we may want to say more about the guidelines about how we should do the reviewing.

Although my introduction here doesn't say very much, the key point I want to get across is that we should try not to be harsh or sound dictatorial in our discussion. The one concrete way I think we can do this is by *not* using the "Approve" and "Request changes" features.