### PR TITLE
Add section: Collaborating on large documents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,16 @@ Anyone is welcome to suggest improvements in one of two ways:
 - Start a discussion by submitting [a new issue](https://github.com/ubuntudesign/webteam-practices/issues/new)
 - Suggest a change by submitting a pull request ([how?](https://help.github.com/articles/about-pull-requests/))
 
+## Submitting suggestions
+
+### Collaborating on large documents
+
+The process of approving small pull-requests can seem overly cumbersome when trying to add significant amounts of content. This will likely be most difficult more towards the project's inception, when there's still not much content, and become less relevant over time.
+
+To get around this it may make more sense to ask the team to collaborate on long documents in an interactive writing tool like [Google Docs](https://docs.google.com/), where many people can quickly build up a shared vision.
+
+The parts of the newly created document should then be submitted as pull requests in the normal way, subject to all the normal rules of approval, but if most of the relevant team members were already involved in the collaborative phase then approval should go by much more easily.
+
 Approving a pull request
 ---
 
@@ -18,4 +28,3 @@ Before a pull request is approved and merged:
 - It should have been open for at least 24 hours
 
 Once it is merged, it should be brought up in the next relevant team meeting to ensure the whole team is aware of the change.
-


### PR DESCRIPTION
This is a new subsection under the "Submitting suggestions" heading suggested in #17.

There have been frustrations about the slow pace of making changes through pull requests, so this is a suggestion for how to ease that frustration.

I hope going forward we might evolve a few different patterns for collaboration that mix the technologies at our disposal. Although ultimately I think it is important to keep a rigorous formal process for approving the final version of any documents.