### PR TITLE
Update copy for vanilla-design-specs.md

### DIFF
--- a/design/vanilla-design-specs.md
+++ b/design/vanilla-design-specs.md
@@ -1,9 +1,9 @@
 ---
-title: Vanilla patterns design specs
+title: Vanilla component design specs
 description: What to include when writing a design spec for a Vanilla pattern
 ---
 
-This document describes what to include when writing a Vanilla pattern design spec.
+This document describes what to include when writing a Vanilla component design spec.
 
 ## Location
 
@@ -11,7 +11,7 @@ Design specs live in the code section of the [Vanilla design repo](https://githu
 
 ## Structure
 
-Each pattern should have its own folder, and include two files:
+Each component should have its own folder, and include two files:
 
 - Detailed written spec (.md format)
 - Visual spec (.png format)
@@ -20,7 +20,7 @@ Each pattern should have its own folder, and include two files:
 
 The detailed spec file should include:
 
-- Title of the pattern: e.g. "[Vanilla: Buttons](https://github.com/ubuntudesign/vanilla-design/blob/master/Buttons/buttons.md)" or "[Brochure theme: Buttons](https://github.com/ubuntudesign/vanilla-brochure-theme-design/blob/master/Buttons/buttons.md)"
+- Title of the component: e.g. "[Vanilla: Buttons](https://github.com/ubuntudesign/vanilla-design/blob/master/Buttons/buttons.md)" or "[Brochure theme: Buttons](https://github.com/ubuntudesign/vanilla-brochure-theme-design/blob/master/Buttons/buttons.md)"
 - All the properties needed to build the pattern: e.g. font size, text colour, padding, borders, shadows, backgrounds
 - Where applicable, include responsive variations for different viewports
 - Where applicable, include: hover, active and focused states
@@ -38,8 +38,8 @@ Written specs should follow the [Canonical copy style guide](https://github.com/
 
 ### Visual spec
 
-The visual specs for the Vanilla and theme patterns live in a single Sketch file (per theme). The latest version of this file can be found in the [root of the design repo](https://github.com/ubuntudesign/vanilla-design).
+The visual specs for Vanilla live in a single Sketch file. The latest version of this file can be found in the [root of the design repo](https://github.com/ubuntudesign/vanilla-design).
 
-Each artboard of the file represents one pattern. This makes it easier to export a flat image of the pattern, which will be its visual spec.
+Each artboard of the file represents one component. This makes it easier to export a flat image of the component, which will be its visual spec.
 
 The visual spec does not have to include any written properties (measurements, etc.), however in some cases adding key values might be useful for quick reference. For example, the size of the icons in the [heading icon pattern](https://github.com/ubuntudesign/vanilla-brochure-theme-design/blob/master/Heading%20icon/heading-icon.png).


### PR DESCRIPTION
## Done
- Updated 'patterns' to 'components'
- Removed reference to themes as we no longer support 😉  

## QA
- Run `jekyll serve`
- Go to `http://127.0.0.1:4000/practices/`
- Scroll to 'Design' and click 'Vanilla design specs'
- Review copy changes above 👍 