### PR TITLE
Switch to YYL naming for iterations

### DIFF
--- a/project-management/iteration-creation.md
+++ b/project-management/iteration-creation.md
@@ -9,13 +9,13 @@ description: These are the steps to follow when creating a new iteration
 
 Go to your squad's repo and create a milestone titled:
 
-Iteration `{YY}`-`{week}` `{date from}` - `{date to}`
+Iteration `{YY}{letter}` ending `{YYYY-MM-DD}`
 
-For example: "Iteration 18-47 20th November - 3rd December."
+For example: “Iteration 19R ending 2019-11-07”
 
 ### Create a small task epic
 
-Create a new epic on the squad repo and attach it to the new milestone. Usually in the format "Small Tasks: Iteration {YY}-{week}"
+Create a new epic on the squad repo and attach it to the new milestone. Usually in the format “Small Tasks {YY}{letter}”
 
 ### Set up the backlog
 


### PR DESCRIPTION
Currently, most squads name their iterations with the last two digits of the year, then the [week number](https://en.wikipedia.org/wiki/Week#Week_numbering) of the full week in the iteration. For example, the week starting 2019-10-28 is W44, so the iteration containing that week is “19-44”.

Since we have two-week iterations, iteration numbers increment by two. And as far as I know, week numbers aren’t common in _any_ of the countries where our team works, and certainly not in most of them. These two factors make the iteration numbers needlessly hard to remember.

Since the start of this year, in my own “squad” I’ve used a different scheme, YYL. 2019’s first iteration was 19A, the second 19B, and so on. Twenty-six letters in the Latin alphabet are enough for a full year of iterations. Advantages:
- Most importantly, it’s easier to spell and pronounce.
- No artificial pressure to have a one-week iteration at the start of the year. For example, if next January most people won’t start back until Monday 6th, we can just start iteration 20A on the 6th.
- No artificial pressure to have a one-week iteration before/after a cross-team sprint. For example, 19-20 was apparently a one-week iteration merely because the second week was a sprint. Using YYL, iteration 19J could just have paused for the duration of the sprint and resumed afterward.

Since it’s worked fine for the past ten months, I propose that we adopt this naming across the team.